### PR TITLE
Add Minikube dev cluster setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 The Airflow Hybrid Orchestrator (AHO) is a distributed workflow orchestration platform built with Apache Airflow 3.0, leveraging a robust control plane/data plane split. It enables scalable, secure, and production-ready workflow automation across cloud, hybrid, and on-premises environments. Workflows are centrally managed and monitored via a secure control plane, while execution is handled by distributed data plane workers, supporting modern hybrid and multi-environment data pipelines.
 
 
+
+## Local Kubernetes development
+
+Scripts and documentation for running a local multi-node Minikube cluster with persistent mounts are available.
+See [docs/minikube-local.md](docs/minikube-local.md) for details.

--- a/docs/minikube-local.md
+++ b/docs/minikube-local.md
@@ -1,0 +1,57 @@
+# Local Minikube Development Cluster
+
+This guide describes how to spin up a local Kubernetes cluster for Airflow development using Minikube.
+
+## Requirements
+
+- Linux with Docker or another Minikube VM driver
+- [minikube](https://minikube.sigs.k8s.io/docs/) and [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- At least 4 CPUs and 8GiB memory available (adjust Docker Desktop resources if necessary)
+
+## Start the cluster
+
+Run the provided script:
+
+```bash
+./scripts/start-minikube.sh
+```
+
+Environment variables can override defaults:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CPUS`   | vCPUs allocated to each node | `4` |
+| `MEMORY` | Memory (MiB) for each node  | `8192` |
+| `NODES`  | Total nodes in the cluster (1 control-plane + workers) | `2` |
+| `DAGS_DIR` | Host path for Airflow DAGs | `./airflow_dags` |
+| `LOGS_DIR` | Host path for Airflow logs | `./airflow_logs` |
+
+## What the script does
+
+- Starts a Minikube profile named `airflow-dev` with multiple nodes.
+- Mounts `DAGS_DIR` to `/mnt/airflow/dags` and `LOGS_DIR` to `/mnt/airflow/logs` inside the cluster nodes.
+- Creates an `airflow` namespace.
+- Prints available storage classes (a default class should be present).
+- Deploys an `airflow-mount-test` pod that writes `minikube mount works` to the mounted DAGs directory.
+
+After the script completes, verify the mount:
+
+```bash
+kubectl -n airflow exec airflow-mount-test -- cat /mnt/dags/test.txt
+ls airflow_dags
+```
+
+You should see the `test.txt` file both in the pod and in the host directory.
+
+## Verification
+
+- `kubectl get nodes` shows one control-plane node and at least one worker.
+- `kubectl get storageclass` lists a default storage class (marked `(default)`).
+- The test pod output confirms the host directory is writable from the cluster.
+
+## Cleanup
+
+```bash
+kubectl delete pod airflow-mount-test -n airflow
+minikube delete -p airflow-dev
+```

--- a/scripts/start-minikube.sh
+++ b/scripts/start-minikube.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure dependencies exist
+command -v minikube >/dev/null 2>&1 || { echo "minikube is required but not installed" >&2; exit 1; }
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl is required but not installed" >&2; exit 1; }
+
+PROFILE=${PROFILE:-airflow-dev}
+NODES=${NODES:-2}
+CPUS=${CPUS:-4}
+MEMORY=${MEMORY:-8192}
+DAGS_DIR=${DAGS_DIR:-"$PWD/airflow_dags"}
+LOGS_DIR=${LOGS_DIR:-"$PWD/airflow_logs"}
+
+mkdir -p "$DAGS_DIR" "$LOGS_DIR"
+
+minikube start -p "$PROFILE" --driver=docker --cpus="$CPUS" --memory="$MEMORY" \
+  --nodes="$NODES" --mount \
+  --mount-string="$DAGS_DIR:/mnt/airflow/dags" \
+  --mount-string="$LOGS_DIR:/mnt/airflow/logs"
+
+kubectl config use-context "$PROFILE" >/dev/null 2>&1 || true
+kubectl create namespace airflow --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl get nodes
+kubectl get storageclass
+
+cat <<'POD' | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: airflow-mount-test
+  namespace: airflow
+spec:
+  containers:
+  - name: writer
+    image: busybox
+    command: ['sh', '-c', 'echo "minikube mount works" > /mnt/dags/test.txt && sleep 3600']
+    volumeMounts:
+    - mountPath: /mnt/dags
+      name: dags
+  restartPolicy: Never
+  volumes:
+  - name: dags
+    hostPath:
+      path: /mnt/airflow/dags
+      type: Directory
+POD
+
+kubectl -n airflow wait --for=condition=Ready pod/airflow-mount-test --timeout=120s
+kubectl -n airflow exec airflow-mount-test -- cat /mnt/dags/test.txt
+echo "Minikube cluster '$PROFILE' is ready."


### PR DESCRIPTION
## Summary
- document how to spin up a local multi-node Minikube cluster
- add script that starts Minikube with host mounts, creates an `airflow` namespace and test pod
- link local Kubernetes instructions from main README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890bbadbfa0832cbfb2f774d150f02e