### PR TITLE
Add minikube config for Airflow POC

### DIFF
--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: minikube.sigs.k8s.io/v1
+kind: ClusterConfig
+name: airflow-poc
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+mounts:
+  - type: bind
+    src: /root/airflow/dags
+    dst: /opt/airflow/dags
+  - type: bind
+    src: /root/airflow/logs
+    dst: /opt/airflow/logs


### PR DESCRIPTION
## Summary
- add minikube-config.yaml for multi-node Airflow POC cluster with host DAG/log mounts

## Testing
- `minikube start -p airflow-poc --nodes=3 --mount --mount-string /root/airflow/dags:/opt/airflow/dags --mount-string /root/airflow/logs:/opt/airflow/logs --driver=docker` *(fails: PROVIDER_DOCKER_NOT_RUNNING)*
- `kubectl create ns airflow` *(fails: The connection to the server localhost:8080 was refused)*

------
https://chatgpt.com/codex/tasks/task_e_6890c34e9514832c8ceb9e5e648a2285