### PR TITLE
Add sample POC DAG

### DIFF
--- a/dags/sample_poc_dag.py
+++ b/dags/sample_poc_dag.py
@@ -1,0 +1,13 @@
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from datetime import datetime
+
+with DAG(
+    'poc_test',
+    start_date=datetime(2025, 8, 1),
+    schedule=None,
+    max_active_tasks=2,
+) as dag:
+    t1 = BashOperator(task_id='echo_hello', bash_command='echo "Hello from pod!"')
+    t2 = BashOperator(task_id='sleep', bash_command='sleep 5')
+    t1 >> t2


### PR DESCRIPTION
## Summary
- add poc_test sample DAG for verifying worker pods

## Testing
- `pytest`
- `airflow tasks test poc_test echo_hello 2025-08-04`
- `kubectl -n airflow get pods -l dag_id=poc_test -o wide` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6890ca19efbc832c952c52bfeb069410