### PR TITLE
docs: add cluster and airflow monitoring setup

### DIFF
--- a/dashboard-adminuser.yaml
+++ b/dashboard-adminuser.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: admin-user
+    namespace: kubernetes-dashboard

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,7 @@
+---
 # values.yaml for Apache Airflow 3 deployment using official Helm chart
-# Configures KubernetesExecutor, persistent volumes, node selectors, service exposure,
-# built-in database and metrics, and minimal resource requests.
+# Configures KubernetesExecutor, persistent volumes, node selectors, service
+# exposure, built-in database and metrics, and minimal resource requests.
 
 image:
   tag: "3.0.3"


### PR DESCRIPTION
## Summary
- document Kubernetes Dashboard setup and Airflow metrics access
- add RBAC manifest for dashboard admin user
- clarify StatsD metrics configuration

## Testing
- `yamllint dashboard-adminuser.yaml values.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6890cbb92ae0832ca0f921003e99f9db